### PR TITLE
Setup the initial Read the Docs page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,45 @@
+# HED tagging NSD images
+This repository contains [Hierarchical Event Descriptors (HED)](https://www.hedtags.org/) labels of 1015 images from the [Natural Scenes Dataset (NSD)](https://naturalscenesdataset.org/) images. This is work in progress...
+
+# Images
+1000 images and their annotations are included in the shared1000_HED.tsv. An additional 15 images and their annotations are included in notShown_HED.tsv. The column titled nsd_id corresponds to the ID of the image as seen in the NSD. The cocoId column corresponds to the indentifier in [COCO](https://cocodataset.org/#home) (note: the images used for NSD and these annotations may be a cropped version of the COCO image). Images are shown to participants with a red fixation dot in the center of the image.
+
+# HED tagging
+All tags are HED validated and are from the standard schema. Both short-form and long-form annotations are included.
+
+## Tagging specifics
+### The following extensions were used throughout the tags (and passed HED validation):
+- Natural-feature/Sky
+- Natural-feature/Ocean
+- Action/Ride
+- Man-made-object/Musical-instrument
+- Man-made-object/Toy
+- Terrain/Sand
+- Agent-trait/
+  - Newborn (birth to 1 month)
+  - Infant (1 month to 1 year)
+  - Child (1 year through 12 years)
+  - Adolescent (13 years through 17 years)
+  - Adult (18 years or older)
+  - Older-adult (65 and older)
+  
+### Foreground and background
+Annotations are grouped into Foreground-view and Background-view sections for all images. Counts and agents are only considered in the Foreground-view.
+
+### Word
+[5 degrees of the visual field is the maximum area in which we can read and comprehend words.](https://doi.org/10.1101/2021.09.14.460238) The Word tag was reserved for images that contained readable words within 5 degrees of the fixation point.
+
+### Numerosity/Count
+Tags only in the foreground of the image include a count and do not specify numbers higher than [4 which is the limit to fast numerosity judgments.](https://doi.org/10.1068/p050327)
+
+### Faces
+The Face tag is always accompanied by an Away-from tag (side-profile) or a Towards tag (full face) as measures of how prominent a face is.
+
+### Agents
+Agent tags (Human-agent and Animal-agent) are used in addition to their Item tags (Human and Animal) when there is evidence of an active motion within the image. Good examples of this are legs in an active walking/running motion, water spray from a surfboard to show it is moving through the water, and snow spray from skis to show movement through the snow.
+
+# Contributors (alphabetically)
+If you make substantial changes to this repository, please also feel free to add your name as a contributor
+- Tal Pal Attia
+- Dora Hermes
+- Claire Holmes 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,14 @@
 # HED tagging NSD images
 This repository contains [Hierarchical Event Descriptors (HED)](https://www.hedtags.org/) labels of 1015 images from the [Natural Scenes Dataset (NSD)](https://naturalscenesdataset.org/) images. This is work in progress...
 
-# Images
+## Images
 1000 images and their annotations are included in the shared1000_HED.tsv. An additional 15 images and their annotations are included in notShown_HED.tsv. The column titled nsd_id corresponds to the ID of the image as seen in the NSD. The cocoId column corresponds to the indentifier in [COCO](https://cocodataset.org/#home) (note: the images used for NSD and these annotations may be a cropped version of the COCO image). Images are shown to participants with a red fixation dot in the center of the image.
 
-# HED tagging
+## HED tagging
 All tags are HED validated and are from the standard schema. Both short-form and long-form annotations are included.
 
-## Tagging specifics
-### The following extensions were used throughout the tags (and passed HED validation):
+### Tagging specifics
+**The following extensions were used throughout the tags (and passed HED validation):**
 - Natural-feature/Sky
 - Natural-feature/Ocean
 - Action/Ride
@@ -23,19 +23,19 @@ All tags are HED validated and are from the standard schema. Both short-form and
   - Adult (18 years or older)
   - Older-adult (65 and older)
   
-### Foreground and background
+**Foreground and background**
 Annotations are grouped into Foreground-view and Background-view sections for all images. Counts and agents are only considered in the Foreground-view.
 
-### Word
+**Word**
 [5 degrees of the visual field is the maximum area in which we can read and comprehend words.](https://doi.org/10.1101/2021.09.14.460238) The Word tag was reserved for images that contained readable words within 5 degrees of the fixation point.
 
-### Numerosity/Count
+**Numerosity/Count**
 Tags only in the foreground of the image include a count and do not specify numbers higher than [4 which is the limit to fast numerosity judgments.](https://doi.org/10.1068/p050327)
 
-### Faces
+**Faces**
 The Face tag is always accompanied by an Away-from tag (side-profile) or a Towards tag (full face) as measures of how prominent a face is.
 
-### Agents
+**Agents**
 Agent tags (Human-agent and Animal-agent) are used in addition to their Item tags (Human and Animal) when there is evidence of an active motion within the image. Good examples of this are legs in an active walking/running motion, water spray from a surfboard to show it is moving through the water, and snow spray from skis to show movement through the snow.
 
 # Contributors (alphabetically)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,1 @@
-mkdocs>=1.1
-mkdocs-material>=5.4
-pymdown-extensions>=7.0.0
-mkdocs-branchcustomization-plugin~=0.1.3
-mkdocs-macros-plugin
-mkdocs-redirects
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,1 @@
+site_name: HED NSD Labels


### PR DESCRIPTION
An initial setup of the webpage with introductory information about the tags

1. Until we need python to set things up on the page, the requirements.txt can be empty
2. index.md is the content of the home page on the website (in this case the exact same as the README.md information)
3. mkdocs.yml is the overall formatting of the markdown webpage

In Read the Docs, we can rebuild the webpage updates by opening the nsd_hed_labels project and building the latest version.